### PR TITLE
Allow lookup by DICOM field name

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -12,7 +12,17 @@ function dcm_init()
     dcm_dict
 end
 
+# Dict for looking up DICOM Tag (Tuple) from the fieldname (String)
+function fieldname_init()
+    fieldname_dict = Dict{AbstractString, Tuple{UInt16,UInt16}}()
+    for d in (_dcmdict_data_::Array{Any,1})
+        fieldname_dict[d[2]] = (UInt16(d[1][1]),UInt16(d[1][2]))
+    end
+    return(fieldname_dict)
+end
+
 const dcm_dict = dcm_init()
+const fieldname_dict = fieldname_init()
 _dcmdict_data_ = 0
 
 """
@@ -44,13 +54,17 @@ type DcmElt
 end
 
 # takes dcm and tag (specify type?)
-function lookup(d, t)
+function lookup(d, t::Tuple)
     for el in d
         if isequal(el.tag,t)
             return el
         end
     end
     return false
+end
+
+function lookup(d, fieldnameString::String)
+    return(lookup(d, fieldname_dict[fieldnameString]))
 end
 
 always_implicit(grp, elt) = (grp == 0xFFFE && (elt == 0xE0DD||elt == 0xE000||


### PR DESCRIPTION
Added a new `lookup` function that uses the field name instead of the hex tag. Hopefully this feature is new and isn't something that already exists that I failed to find.
The PR shouldn't affect any existing functionality of the package, and still passes `Pkg.test()`.

Motivation: I use `lookup` to get information from the parsed dicom file (that is its purpose, right?) but I am bad at remembering the tag values. For some reason, "(0x0008,0x103E)" isn't quite as memorable as "Series Description".  

**Quick test in Julia:**  
Loading test data (copy/paste from `runtests.jl`):
```
julia> using DICOM

julia> filename = tempname()*".zip"
"/tmp/juliaFynNZN.zip"

julia> dir = tempname()
"/tmp/juliahKICEn"

julia> mkpath(dir)

julia> download("http://www.dclunie.com/images/pixelspacingtestimages.zip", filename)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 59033  100 59033    0     0  59033      0  0:00:01 --:--:--  0:00:01  122k
"/tmp/juliaFynNZN.zip"

julia> run(`unzip $filename -d $dir`)
Archive:  /tmp/juliaFynNZN.zip
  inflating: /tmp/juliahKICEn/DISCIMG/DICOMDIR  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/MGIMAGEA  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/DXIMAGEA  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/CRIMAGEA  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/XAIMAGEA  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/MGIMAGEI  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/DXIMAGEI  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/CRIMAGEI  
  inflating: /tmp/juliahKICEn/DISCIMG/IMAGES/XAIMAGEI  
  inflating: /tmp/juliahKICEn/README  

julia> d = dcm_parse(joinpath(dir, "DISCIMG/IMAGES/MGIMAGEA"));
```
Original `lookup` function still works, e.g. the Series Description can be obtained by:
```
julia> lookup(d, (0x0008,0x103E)).data[1][1]
"Mammography - Pixel Spacing and Imager Pixel Spacing"
```
But now we can also use the field name
```
julia> lookup(d, "Series Description").data[1][1]
"Mammography - Pixel Spacing and Imager Pixel Spacing"
```
We can just as easily look at other properties
```
julia> lookup(d, "Patient ID").data[1][1]
"62354PQGRRST"

julia> lookup(d, "Patient's Name").data[1][1]
"Test^PixelSpacing "

julia> lookup(d, "Study Description").data[1][1]
"Test support of different pixel spacing attributes"
```
... and the image data can be obtained by `lookup(d, "Pixel Data").data[1]`

 

