### PR TITLE
Fix for `Pkg.test("DICOM")` on Windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,7 @@
 using DICOM
 
-filename = tempname()*".zip"
-dir = tempname()
-mkpath(dir)
+dir = mktempdir()
+filename = joinpath(dir,"dicomTestData.zip")
 
 download("http://www.dclunie.com/images/pixelspacingtestimages.zip", filename)
 run(`unzip $filename -d $dir`)


### PR DESCRIPTION
`Pkg.test("DICOM")` was working for me on Linux, but didn't work on Windows. This PR should fix that.

Seems the issue is that `tempname()` creates a new file on Windows (see https://github.com/JuliaLang/julia/issues/9053). 
So doing `dir = tempname()` and then  `mkpath(dir)` produces an error because `dir` already exists - as a file.

Fix is to use `dir = mktempdir()`, which works on both Windows and Linux.  
I also gave the zip file a name in order to avoid using `tempname()`. Could've replaced it with `randstring()`, but I didn't see the need for it to have a random name.
