### PR TITLE
Update deprected syntax of unspecified_length()

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -133,7 +133,7 @@ function dcm_store(st::IOStream, gelt::Tuple{UInt16,UInt16}, writef::Function, v
 end
 
 function undefined_length(st, vr)
-    data = memio()
+    data = IOBuffer()
     w1 = w2 = 0
     while true
         # read until 0xFFFE 0xE0DD
@@ -150,7 +150,7 @@ function undefined_length(st, vr)
         end
     end
     skip(st, 4)
-    takebuf_array(data)
+    take!(data)
 end
 
 function sequence_item(st::IOStream, evr, sz)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,14 +135,19 @@ dVR_CTb = Dict( (0x0000,0x0000) => "",  (0x0018,0x1170) => "DS")
 dcmCTb = dcm_parse(fileCT, header=false, dVR=dVR_CTb);
 
 # 3. Loading DICOM file containing multiple frames
-
 fileMR_multiframe = joinpath(testdir, "MR-Explicit_Little_MultiFrame")
 if !isfile(fileMR_multiframe)
     download("http://www.barre.nom.fr/medical/samples/files/MR-MONO2-8-16x-heart.gz", fileMR_multiframe*".gz")
     run(`gunzip -f $(fileMR_multiframe*".gz")`)
 end
-
 dcmMR_multiframe = dcm_parse(fileMR_multiframe)
+
+# 4. Load DICOM with unspecified_length()
+fileMR_UnspecifiedLength = joinpath(testdir, "MR-UnspecifiedLength")
+if !isfile(fileMR_UnspecifiedLength)
+    download("https://drive.google.com/uc?export=download&id=1lm0750H-1O22O7Bqy0yfq0FK_vDrqC7-", fileMR_UnspecifiedLength)
+end
+dcmMR_UnspecifiedLength = dcm_parse(fileMR_UnspecifiedLength)
 
 @testset "Loading uncommon DICOM data" begin
     @test dcmOT[(0x0008,0x0060)] == "OT"
@@ -153,6 +158,8 @@ dcmMR_multiframe = dcm_parse(fileMR_multiframe)
     @test !haskey(dcmCTb, (0x0028,0x0040)) # dcmCTb skips retired elements
 
     @test dcmMR_multiframe[(0x0008,0x0060)] == "MR"
+
+    @test size(dcmMR_UnspecifiedLength[tag"Pixel Data"]) === (256, 256, 27)
 end
 
 @testset "tag" begin


### PR DESCRIPTION
This went under the radar since none of the existing tests require the `unspecified_length()` function.
The deprecated syntax has been updated, and a new test image was added that makes use of the function.