### PR TITLE
Support parsing of big-endian & RGB files. Also refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: julia
 os:
-    - linux
-    - osx
+  - linux
+  - osx
+  - windows
 julia:
-    - 1.0
-    - 1.2
-    - nightly
+  - 1.0
+  - 1.2
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
-    email: false
+  email: false
 after_success:
-    - julia -e 'using Pkg; import DICOM; cd(joinpath(dirname(pathof(DICOM)),"../")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -460,8 +460,8 @@ function dcm_write(fn::String, d::Dict{Tuple{UInt16,UInt16},Any}; kwargs...)
     return fn
 end
 
-function dcm_write(st::IO, dcm::Dict{Tuple{UInt16,UInt16},Any}; header=true, aux_vr=Dict{Tuple{UInt16,UInt16},String}())
-    if header
+function dcm_write(st::IO, dcm::Dict{Tuple{UInt16,UInt16},Any}; preamble=true, aux_vr=Dict{Tuple{UInt16,UInt16},String}())
+    if preamble
         write(st, zeros(UInt8, 128))
         write(st, "DICM")
     end

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -382,12 +382,12 @@ function pixeldata_parse(st::IO, sz, vr::String, dcm, endian)
    # (0028,0010) defines number of rows
    f = get(dcm, (0x0028,0x0010), nothing)
    if f !== nothing
-       xr = Int(f)
+       yr = Int(f)
    end
    # (0028,0011) defines number of columns
    f = get(dcm, (0x0028,0x0011), nothing)
    if f !== nothing
-       yr = Int(f)
+       xr = Int(f)
    end
    # (0028,0012) defines number of planes
    f = get(dcm, (0x0028,0x0012), nothing)
@@ -399,9 +399,17 @@ function pixeldata_parse(st::IO, sz, vr::String, dcm, endian)
    if f !== nothing
        zr *= Int(f)
    end
+   # (0x0028, 0x0002) defines number of samples per pixel
+   f = get(dcm, (0x0028, 0x0002), nothing)
+   if f !== nothing
+       samples_per_pixel = Int(f)
+   else
+       samples_per_pixel = 1
+   end
    if sz != 0xffffffff
-       data =
-       zr > 1 ? Array{dtype}(undef, xr, yr, zr) : Array{dtype}(undef, xr, yr)
+       data_dims = [xr, yr, zr, samples_per_pixel]
+       data_dims = data_dims[data_dims .> 1]
+       data = Array{dtype}(undef, data_dims...)
        read!(st, data)
    else
        # start with Basic Offset Table Item

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -74,9 +74,460 @@ function lookup(d::Dict{Tuple{UInt16,UInt16},Any}, fieldnameString::String)
     return(get(d, fieldname_dict[fieldnameString], nothing))
 end
 
+if ENDIAN_BOM == 0x04030201
+    order(x, endian) = endian == :little ? x : bswap.(x)
+else
+    order(x, endian) = endian == :big ? x : bswap.(x)
+end
+
 always_implicit(grp, elt) = (grp == 0xFFFE && (elt == 0xE0DD||elt == 0xE000||
                                                elt == 0xE00D))
 
+"""
+   dcm_parse(fn::AbstractString)
+
+Reads file fn and returns a Dict
+"""
+function dcm_parse(fn::AbstractString; kwargs...)
+   st = open(fn)
+   dcm = dcm_parse(st; kwargs...)
+   close(st)
+   dcm
+end
+
+"""
+   dcm_parse(st::IO)
+
+Reads IO st and returns a Dict
+"""
+function dcm_parse(st::IO; return_vr=false, header=true, max_group=0xffff, aux_vr=Dict{Tuple{UInt16,UInt16},String}())
+   if header
+       check_header(st)
+   end
+   dcm = read_preamble(st)
+   is_explicit, endian = determine_explicitness_and_endianness(dcm)
+   file_properties = (is_explicit=is_explicit, endian=endian, aux_vr=aux_vr)
+   (dcm, vr) = read_body(st, dcm, file_properties; max_group=max_group)
+   if return_vr
+       return dcm, vr
+   else
+       return dcm
+   end
+end
+
+function check_header(st)
+   # First 128 bytes are preamble - should be skipped
+   skip(st, 128)
+   # "DICM" identifier must be after preamble
+   sig = String(read!(st,Array{UInt8}(undef, 4)))
+   if sig != "DICM"
+       error("dicom: invalid file header")
+   end
+   return
+end
+
+# Pre-ample is always explicit VR / little endian
+function read_preamble(st::IO)
+   dcm = Dict{Tuple{UInt16,UInt16},Any}()
+   is_explicit = true
+   endian = :little
+   while true
+       pos = position(st)
+       (gelt, data, vr) = read_element(st, (is_explicit, endian, emptyDcmDict))
+       grp = gelt[1]
+       if grp > 0x0002 || gelt == emptyTag
+           seek(st, pos)
+           return dcm
+       else
+           dcm[gelt] = data
+       end
+   end
+   error("Unexpected break from loop while reading preamble")
+end
+
+function determine_explicitness_and_endianness(dcm)
+   # Default is implicit_vr & little-endian
+   if !haskey(dcm, (0x0002, 0x0010))
+       return (false, :little)
+   end
+   metaInfo = get(meta_uids, dcm[(0x0002,0x0010)], (false, true))
+   explicitness = metaInfo[2]
+   if metaInfo[1]
+       endianness = :big
+   else
+       endianness = :little
+   end
+   return explicitness, endianness
+end
+
+function read_body(st, dcm, props; max_group)
+   vrs = Dict{Tuple{UInt16,UInt16},String}()
+   while true
+       (gelt, data, vr) = read_element(st, props, dcm)
+       if gelt == emptyTag || gelt[1] > max_group
+           break
+       else
+           dcm[gelt] = data
+           vrs[gelt] = vr
+       end
+   end
+   return dcm, vrs
+end
+
+function read_element(st::IO, props, dcm=emptyDcmDict)
+   (is_explicit, endian, aux_vr) = props
+   local grp
+   try
+       grp = read_group_tag(st, endian)
+   catch
+       return(emptyTag,0,emptyVR)
+   end
+   elt = read_element_tag(st, endian)
+   gelt = (grp, elt)
+   vr, lentype = determine_vr_and_lentype(st, gelt, is_explicit, aux_vr)
+   sz = read_element_size(st, lentype, endian)
+   # Empty VR can be supplied in aux_vr to skip an element
+   if isempty(vr)
+       sz = isodd(sz) ? sz+1 : sz
+       skip(st,sz)
+       return(read_element(st::IO, props, dcm))
+   end
+
+   data =
+   vr=="ST" || vr=="LT" || vr=="UT" || vr=="AS" ? String(read!(st, Array{UInt8}(undef, sz))) :
+
+   sz==0 || vr=="XX" ? Any[] :
+
+   vr == "SQ" ? sequence_parse(st, sz, props) :
+
+   gelt == (0x7FE0,0x0010) ? pixeldata_parse(st, sz, vr, dcm, endian) :
+
+   sz == 0xffffffff ? undefined_length(st, vr) :
+
+   vr == "FL" ? numeric_parse(st, Float32, sz, endian) :
+   vr == "FD" ? numeric_parse(st, Float64, sz, endian) :
+   vr == "SL" ? numeric_parse(st, Int32  , sz, endian) :
+   vr == "SS" ? numeric_parse(st, Int16  , sz, endian) :
+   vr == "UL" ? numeric_parse(st, UInt32 , sz, endian) :
+   vr == "US" ? numeric_parse(st, UInt16 , sz, endian) :
+
+   vr == "OB" ? order(read!(st, Array{UInt8}(undef, sz)), endian)        :
+   vr == "OF" ? order(read!(st, Array{Float32}(undef, div(sz,4))), endian) :
+   vr == "OW" ? order(read!(st, Array{UInt16}(undef, div(sz,2))), endian) :
+
+   vr == "AT" ? [ order(read!(st, Array{UInt16}(undef, 2)), endian) for n=1:div(sz,4) ] :
+
+   vr == "DS" ? map(x->x == "" ? 0.0 : parse(Float64,x), string_parse(st, sz, 16, false)) :
+   vr == "IS" ? map(x->x == "" ? 0 : parse(Int,x), string_parse(st, sz, 12, false)) :
+
+   vr == "AE" ? string_parse(st, sz, 16, false) :
+   vr == "CS" ? string_parse(st, sz, 16, false) :
+   vr == "SH" ? string_parse(st, sz, 16, false) :
+   vr == "LO" ? string_parse(st, sz, 64, false) :
+   vr == "UI" ? string_parse(st, sz, 64, false) :
+   vr == "PN" ? string_parse(st, sz, 64, true)  :
+
+   vr == "DA" ? string_parse(st, sz, 10, true) :
+   vr == "DT" ? string_parse(st, sz, 26, false) :
+   vr == "TM" ? string_parse(st, sz, 16, false) :
+   order(read!(st, Array{UInt8}(undef, sz)), endian)
+
+   if isodd(sz) && sz != 0xffffffff
+       skip(st, 1)
+   end
+
+   # For convenience, get rid of array if it is just acting as a container
+   # Exception is "SQ", where array is part of structure
+   if length(data) == 1 && vr != "SQ"
+       data = data[1]
+       # Sometimes it is necessary to go one level deeper
+       if length(data) == 1
+           data = data[1]
+       end
+   end
+
+   return(gelt, data, vr)
+end
+
+read_group_tag(st, endian) = order(read(st, UInt16), endian)
+read_element_tag = read_group_tag
+read_element_size(st, lentype, endian) = order(read(st,lentype), endian)
+
+function determine_vr_and_lentype(st, gelt, is_explicit, aux_vr)
+   (grp, elt) = gelt
+   lentype = UInt32
+   if is_explicit && !always_implicit(grp, elt)
+       vr = String(read!(st, Array{UInt8}(undef, 2)))
+       if vr in ("OB", "OW", "OF", "SQ", "UT", "UN")
+           skip(st, 2)
+       else
+           lentype = UInt16
+       end
+       diffvr = !isequal(vr, lookup_vr(gelt))
+   else
+       vr = elt == 0x0000 ? "UL" : lookup_vr(gelt)
+   end
+   if isodd(grp) && grp > 0x0008 && 0x0010 <= elt <+ 0x00FF
+       # Private creator
+       vr = "LO"
+   elseif isodd(grp) && grp > 0x0008
+       # Assume private
+       vr = "UN"
+   end
+   if haskey(aux_vr, gelt)
+       vr = aux_vr[gelt]
+   end
+   if vr === emptyVR
+       if haskey(aux_vr, (0x0000,0x0000))
+           vr = aux_vr[(0x0000,0x0000)]
+       elseif !haskey(aux_vr, gelt)
+           error("dicom: unknown tag ", gelt)
+       end
+   end
+   return vr, lentype
+end
+
+numeric_parse(st::IO, T::DataType, sz, endian) = order(T[read(st, T) for i=1:div(sz,sizeof(T))], endian)
+
+function string_parse(st, sz, maxlen, spaces)
+   endpos = position(st)+sz
+   data = [ "" ]
+   first = true
+   while position(st) < endpos
+       c = !first||spaces ? read(st,Char) : skip_spaces(st, endpos)
+       if c == '\\'
+           push!(data, "")
+           first = true
+       elseif c == '\0'
+           break
+       else
+           data[end] = string(data[end],c)  # TODO: inefficient
+           first = false
+       end
+   end
+   if !spaces
+       return map(rstrip,data)
+   end
+   return data
+end
+
+function skip_spaces(st, endpos)
+   while true
+       c = read(st,Char)
+       if c != ' ' || position(st) == endpos
+           return c
+       end
+   end
+end
+
+function sequence_parse(st, sz, props)
+   (is_explicit, endian, aux_vr) = props
+   sq = Array{Dict{Tuple{UInt16,UInt16},Any},1}()
+   while sz > 0
+       grp = read_group_tag(st, endian)
+       elt = read_element_tag(st, endian)
+       itemlen = read_element_size(st, UInt32, endian)
+       if grp==0xFFFE && elt==0xE0DD
+           return sq
+       end
+       if grp != 0xFFFE || elt != 0xE000
+           error("dicom: expected item tag in sequence")
+       end
+       push!(sq, sequence_item(st, itemlen, props))
+       sz -= 8 + (itemlen != 0xffffffff) * itemlen
+   end
+   return sq
+end
+
+function sequence_item(st::IO, sz, props)
+   item = Dict{Tuple{UInt16,UInt16},Any}()
+   endpos = position(st) + sz
+   while position(st) < endpos
+       (gelt, data, vr) = read_element(st, props)
+       if isequal(gelt, (0xFFFE,0xE00D))
+           break
+       end
+       item[gelt] = data
+   end
+   return item
+end
+
+# always little-endian, "encapsulated" iff sz==0xffffffff
+function pixeldata_parse(st::IO, sz, vr::String, dcm, endian)
+   # (0x0028,0x0103) defines Pixel Representation
+   isSigned = false
+   f = get(dcm, (0x0028,0x0103), nothing)
+   if f !== nothing
+       # Data is signed if f==1
+       isSigned = f == 1
+   end
+   # (0x0028,0x0100) defines Bits Allocated
+   bitType = 16
+   f = get(dcm, (0x0028,0x0100), nothing)
+   if f !== nothing
+       bitType = Int(f)
+   else
+       f = get(dcm, (0x0028,0x0101), nothing)
+       bitType = f !== nothing ? Int(f) :
+           vr == "OB" ? 8 : 16
+   end
+   if bitType == 8
+       dtype = isSigned ? Int8 : UInt8
+   else
+       dtype = isSigned ? Int16 : UInt16
+   end
+
+   yr=1
+   zr=1
+   # (0028,0010) defines number of rows
+   f = get(dcm, (0x0028,0x0010), nothing)
+   if f !== nothing
+       xr = Int(f)
+   end
+   # (0028,0011) defines number of columns
+   f = get(dcm, (0x0028,0x0011), nothing)
+   if f !== nothing
+       yr = Int(f)
+   end
+   # (0028,0012) defines number of planes
+   f = get(dcm, (0x0028,0x0012), nothing)
+   if f !== nothing
+       zr = Int(f)
+   end
+   # (0028,0008) defines number of frames
+   f = get(dcm, (0x0028,0x0008), nothing)
+   if f !== nothing
+       zr *= Int(f)
+   end
+   if sz != 0xffffffff
+       data =
+       zr > 1 ? Array{dtype}(undef, xr, yr, zr) : Array{dtype}(undef, xr, yr)
+       read!(st, data)
+   else
+       # start with Basic Offset Table Item
+       data = Array{Any,1}(element(st, false)[2])
+       while true
+           grp = read_group_tag(st, endian)
+           elt = read_element_tag(st, endian)
+           xr = read_element_size(st, UInt32, endian)
+           if grp == 0xFFFE && elt == 0xE0DD
+               return data
+           end
+           if grp != 0xFFFE || elt != 0xE000
+               error("dicom: expected item tag in encapsulated pixel data")
+           end
+           if dtype === UInt16; xr = div(xr,2); end
+           push!(data, read!(st, Array{dtype}(undef, xr)))
+       end
+   end
+   return order.(data, endian)
+end
+
+function undefined_length(st, vr)
+    data = IOBuffer()
+    w1 = w2 = 0
+    while true
+        # read until 0xFFFE 0xE0DD
+        w1 = w2
+        w2 = read(st, UInt16)
+        if w1 == 0xFFFE
+            if w2 == 0xE0DD
+                break
+            end
+            write(data, w1)
+        end
+        if w2 != 0xFFFE
+            write(data, w2)
+        end
+    end
+    skip(st, 4)
+    take!(data)
+end
+
+
+function dcm_write(fn::String, d::Dict{Tuple{UInt16,UInt16},Any}; kwargs...)
+    st = open(fn,"w+")
+    dcm_write(st, d; kwargs...)
+    close(st)
+    return fn
+end
+
+function dcm_write(st::IO, dcm::Dict{Tuple{UInt16,UInt16},Any}; header=true, aux_vr=Dict{Tuple{UInt16,UInt16},String}())
+    if header
+        write(st, zeros(UInt8, 128))
+        write(st, "DICM")
+    end
+    (is_explicit, endian) = determine_explicitness_and_endianness(dcm)
+
+    for gelt in sort(collect(keys(dcm)))
+        write_element(st, gelt, dcm[gelt], is_explicit, aux_vr)
+    end
+    return
+end
+
+function write_element(st::IO, gelt::Tuple{UInt16,UInt16}, data, is_explicit, aux_vr)
+    if haskey(aux_vr, gelt)
+        vr = aux_vr[gelt]
+    else
+        vr = lookup_vr(gelt)
+    end
+    if vr === emptyVR
+        # Element tags ending in 0x0000 are not included in dcm_dicm.jl, their vr is UL
+        if gelt[2] == 0x0000
+            vr = "UL"
+        elseif isodd(gelt[1]) && gelt[1] > 0x0008 && 0x0010 <= gelt[2] <+ 0x00FF
+                # Private creator
+                vr = "LO"
+        elseif isodd(gelt[1]) && gelt[1] > 0x0008
+                # Assume private
+                vr = "UN"
+        else
+            error("dicom: unknown tag ", gelt)
+        end
+    end
+    if gelt == (0x7FE0, 0x0010)
+        return pixeldata_write(st, data, is_explicit)
+    end
+
+    if vr == "SQ"
+        vr = is_explicit ? vr : emptyVR
+        return dcm_store(st, gelt,
+                         s->sequence_write(s, data, is_explicit), vr)
+    end
+
+    # Pack data into array container. This is to undo "data = data[1]" from read_element().
+    if !isa(data, Array) && vr in ("FL","FD","SL","SS","UL","US")
+        data = [data]
+    end
+
+    data =
+    isempty(data) ? UInt8[] :
+    vr in ("OB","OF","OW","ST","LT","UT") ? data :
+    vr in ("AE", "CS", "SH", "LO", "UI", "PN", "DA", "DT", "TM") ?
+        string_write(data, 0) :
+    vr == "FL" ? convert(Array{Float32,1}, data) :
+    vr == "FD" ? convert(Array{Float64,1}, data) :
+    vr == "SL" ? convert(Array{Int32,1},   data) :
+    vr == "SS" ? convert(Array{Int16,1},   data) :
+    vr == "UL" ? convert(Array{UInt32,1},  data) :
+    vr == "US" ? convert(Array{UInt16,1},  data) :
+    vr == "AT" ? [data...] :
+    vr in ("DS","IS") ? string_write(map(string,data), 0) :
+    data
+
+    if !is_explicit && gelt[1]>0x0002
+        vr = emptyVR
+    end
+
+    dcm_store(st, gelt, s->write(s, data), vr)
+end
+
+string_write(vals::Array{SubString{String}}, maxlen) = string_write(convert(Array{String}, vals), maxlen)
+string_write(vals::SubString{String}, maxlen) = string_write(convert(String, vals), maxlen)
+string_write(vals::Tuple{String, String}, maxlen) = string_write(collect(vals), maxlen)
+string_write(vals::Char, maxlen) = string_write(string(vals), maxlen)
+string_write(vals::String, maxlen) = string_write([vals], maxlen)
+string_write(vals::Array{String,1}, maxlen) = join(vals, '\\')
 
 dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function) = dcm_store(st, gelt, writef, emptyVR)
 function dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function, vr::String)
@@ -114,150 +565,23 @@ function dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function, vr::Str
     end
 end
 
-function undefined_length(st, vr)
-    data = IOBuffer()
-    w1 = w2 = 0
-    while true
-        # read until 0xFFFE 0xE0DD
-        w1 = w2
-        w2 = read(st, UInt16)
-        if w1 == 0xFFFE
-            if w2 == 0xE0DD
-                break
-            end
-            write(data, w1)
-        end
-        if w2 != 0xFFFE
-            write(data, w2)
-        end
-    end
-    skip(st, 4)
-    take!(data)
-end
-
-<<<<<<< HEAD
-function sequence_item(st::IO, evr, sz)
-=======
-
-function sequence_item(st::IOStream, evr, sz,endian)
->>>>>>> 5f0a7db7c88445881eeab22fda25863c32a41292
-    item = Dict{Tuple{UInt16,UInt16},Any}()
-    endpos = position(st) + sz
-    while position(st) < endpos
-          (gelt, data, vr) = element(st, evr,endian)
-        if isequal(gelt, (0xFFFE,0xE00D))
-            break
-        end
-        item[gelt] = data
-    end
-    return item
-end
-
-function sequence_item_write(st::IO, evr::Bool, items::Dict{Tuple{UInt16,UInt16},Any})
-    for gelt in sort(collect(keys(items)))
-        element_write(st, evr, gelt, items[gelt])
-    end
-    write(st, UInt16[0xFFFE, 0xE00D, 0x0000, 0x0000])
-end
-
-function sequence_parse(st, evr, sz,endian)
-    sq = Array{Dict{Tuple{UInt16,UInt16},Any},1}()
-    while sz > 0
-        grp = order(read(st, UInt16), endian)
-        elt = order(read(st, UInt16), endian)
-        itemlen = order(read(st, UInt32), endian)
-        if grp==0xFFFE && elt==0xE0DD
-            return sq
-        end
-        if grp != 0xFFFE || elt != 0xE000
-            error("dicom: expected item tag in sequence")
-        end
-        push!(sq, sequence_item(st, evr, itemlen, endian))
-        sz -= 8 + (itemlen != 0xffffffff) * itemlen
-    end
-    return sq
-end
-
-function sequence_write(st::IO, evr::Bool, items::Array{Dict{Tuple{UInt16,UInt16},Any},1})
+function sequence_write(st::IO, items::Array{Dict{Tuple{UInt16,UInt16},Any},1}, evr)
     for subitem in items
         if length(subitem) > 0
-            dcm_store(st, (0xFFFE,0xE000), s->sequence_item_write(s, evr, subitem))
+            dcm_store(st, (0xFFFE,0xE000), s->sequence_item_write(s, subitem, evr))
         end
     end
     write(st, UInt16[0xFFFE, 0xE0DD, 0x0000, 0x0000])
 end
 
-# always little-endian, "encapsulated" iff sz==0xffffffff
-function pixeldata_parse(st::IO, sz, vr::String, dcm=emptyDcmDict)
-    # (0x0028,0x0103) defines Pixel Representation
-    isSigned = false
-    f = get(dcm, (0x0028,0x0103), nothing)
-    if f !== nothing
-        # Data is signed if f==1
-        isSigned = f == 1
+function sequence_item_write(st::IO, items::Dict{Tuple{UInt16,UInt16},Any}, evr)
+    for gelt in sort(collect(keys(items)))
+        write_element(st, gelt, items[gelt], evr, emptyDcmDict)
     end
-    # (0x0028,0x0100) defines Bits Allocated
-    bitType = 16
-    f = get(dcm, (0x0028,0x0100), nothing)
-    if f !== nothing
-        bitType = Int(f)
-    else
-        f = get(dcm, (0x0028,0x0101), nothing)
-        bitType = f !== nothing ? Int(f) :
-            vr == "OB" ? 8 : 16
-    end
-    if bitType == 8
-        dtype = isSigned ? Int8 : UInt8
-    else
-        dtype = isSigned ? Int16 : UInt16
-    end
-    yr=1
-    zr=1
-    # (0028,0010) defines number of rows
-    f = get(dcm, (0x0028,0x0010), nothing)
-    if f !== nothing
-        xr = Int(f)
-    end
-    # (0028,0011) defines number of columns
-    f = get(dcm, (0x0028,0x0011), nothing)
-    if f !== nothing
-        yr = Int(f)
-    end
-    # (0028,0012) defines number of planes
-    f = get(dcm, (0x0028,0x0012), nothing)
-    if f !== nothing
-        zr = Int(f)
-    end
-    # (0028,0008) defines number of frames
-    f = get(dcm, (0x0028,0x0008), nothing)
-    if f !== nothing
-        zr *= Int(f)
-    end
-    if sz != 0xffffffff
-        data =
-        zr > 1 ? Array{dtype}(undef, xr, yr, zr) : Array{dtype}(undef, xr, yr)
-        read!(st, data)
-    else
-        # start with Basic Offset Table Item
-        data = Array{Any,1}(element(st, false)[2])
-        while true
-            grp = read(st, UInt16)
-            elt = read(st, UInt16)
-            xr = read(st, UInt32)
-            if grp == 0xFFFE && elt == 0xE0DD
-                return data
-            end
-            if grp != 0xFFFE || elt != 0xE000
-                error("dicom: expected item tag in encapsulated pixel data")
-            end
-            if dtype === UInt16; xr = div(xr,2); end
-            push!(data, read!(st, Array{dtype}(undef, xr)))
-        end
-    end
-    return data
+    write(st, UInt16[0xFFFE, 0xE00D, 0x0000, 0x0000])
 end
 
-function pixeldata_write(st, evr, d)
+function pixeldata_write(st, d, evr)
     # if length(el) > 1
     #     error("dicom: compression not supported")
     # end
@@ -273,328 +597,6 @@ function pixeldata_write(st, evr, d)
     else
         dcm_store(st, (0x7FE0,0x0010), s->write(s,d))
     end
-end
-
-function skip_spaces(st, endpos)
-    while true
-        c = read(st,Char)
-        if c != ' ' || position(st) == endpos
-            return c
-        end
-    end
-    return '\0'
-end
-
-function string_parse(st, sz, maxlen, spaces)
-    endpos = position(st)+sz
-    data = [ "" ]
-    first = true
-    while position(st) < endpos
-        c = !first||spaces ? read(st,Char) : skip_spaces(st, endpos)
-        if c == '\\'
-            push!(data, "")
-            first = true
-        elseif c == '\0'
-            break
-        else
-            data[end] = string(data[end],c)  # TODO: inefficient
-            first = false
-        end
-    end
-    if !spaces
-        return map(rstrip,data)
-    end
-    return data
-end
-
-numeric_parse(st::IO, T::DataType, sz) = T[read(st, T) for i=1:div(sz,sizeof(T))]
-
-<<<<<<< HEAD
-function element(st::IO, evr::Bool, dcm=emptyDcmDict, dVR=Dict{Tuple{UInt16,UInt16},String}())
-=======
-
-if ENDIAN_BOM == 0x04030201
-  order(x, endian) = endian == :little ? x : bswap.(x)
-else
-  order(x, endian) = endian == :big ? x : bswap.(x)
-end
-
-function element(st::IOStream, evr::Bool, endian=:little, dcm=emptyDcmDict, dVR=Dict{Tuple{UInt16,UInt16},String}())
->>>>>>> 5f0a7db7c88445881eeab22fda25863c32a41292
-    lentype = UInt32
-    diffvr = false
-    local grp
-    try
-        grp = read(st, UInt16)
-    catch
-        return(emptyTag,0,emptyVR)
-    end
-    if grp <= 0x0002
-<<<<<<< HEAD
-=======
-        endian = :little
->>>>>>> 5f0a7db7c88445881eeab22fda25863c32a41292
-        evr = true
-    end
-    grp = order(grp, endian)
-    elt = order(read(st, UInt16), endian)
-    gelt = (grp,elt)
-    if evr && !always_implicit(grp,elt)
-        vr = String(read!(st, Array{UInt8}(undef, 2)))
-        if vr in ("OB", "OW", "OF", "SQ", "UT", "UN")
-            skip(st, 2)
-        else
-            lentype = UInt16
-        end
-        diffvr = !isequal(vr, lookup_vr(gelt))
-    else
-        vr = elt == 0x0000 ? "UL" : lookup_vr(gelt)
-    end
-    if isodd(grp) && grp > 0x0008 && 0x0010 <= elt <+ 0x00FF
-        # Private creator
-        vr = "LO"
-    elseif isodd(grp) && grp > 0x0008
-        # Assume private
-        vr = "UN"
-    end
-    if haskey(dVR, gelt)
-        vr = dVR[gelt]
-    end
-    if vr === emptyVR
-        if haskey(dVR, (0x0000,0x0000))
-            vr = dVR[(0x0000,0x0000)]
-        elseif !haskey(dVR, gelt)
-            error("dicom: unknown tag ", gelt)
-        end
-    end
-
-    sz = order(read(st,lentype), endian)
-
-    # Empty VR can be supplied in dVR to skip an element
-    if vr == ""
-        sz = isodd(sz) ? sz+1 : sz
-        skip(st,sz)
-        return(element(st,evr,endian,dcm,dVR))
-    end
-
-    data =
-    vr=="ST" || vr=="LT" || vr=="UT" || vr=="AS" ? String(read!(st, Array{UInt8}(undef, sz))) :
-
-    sz==0 || vr=="XX" ? Any[] :
-
-    vr == "SQ" ? sequence_parse(st, evr, sz, endian) :
-
-    gelt == (0x7FE0,0x0010) ? pixeldata_parse(st, sz, vr, dcm) :
-
-    sz == 0xffffffff ? undefined_length(st, vr) :
-
-    vr == "FL" ? order(numeric_parse(st, Float32, sz), endian) :
-    vr == "FD" ? order(numeric_parse(st, Float64, sz), endian) :
-    vr == "SL" ? order(numeric_parse(st, Int32  , sz), endian) :
-    vr == "SS" ? order(numeric_parse(st, Int16  , sz), endian) :
-    vr == "UL" ? order(numeric_parse(st, UInt32 , sz), endian) :
-    vr == "US" ? order(numeric_parse(st, UInt16 , sz), endian) :
-
-    vr == "OB" ? order(read(st, UInt8  , sz),endian)        :
-    vr == "OF" ? order(read(st, Float32, div(sz,4)), endian) :
-    vr == "OW" ? order(read(st, UInt16 , div(sz,2)), endian) :
-
-    vr == "AT" ? [ order(read(st,UInt16,2), endian) for n=1:div(sz,4) ] :
-
-    vr == "AT" ? [ read!(st, Array{UInt16}(undef, 2)) for n=1:div(sz,4) ] :
-
-    vr == "DS" ? map(x->x=="" ? 0. : parse(Float64,x), string_parse(st, sz, 16, false)) :
-    vr == "IS" ? map(x->x=="" ? 0  : parse(Int,x), string_parse(st, sz, 12, false)) :
-
-    vr == "AE" ? string_parse(st, sz, 16, false) :
-    vr == "CS" ? string_parse(st, sz, 16, false) :
-    vr == "SH" ? string_parse(st, sz, 16, false) :
-    vr == "LO" ? string_parse(st, sz, 64, false) :
-    vr == "UI" ? string_parse(st, sz, 64, false) :
-    vr == "PN" ? string_parse(st, sz, 64, true)  :
-
-    vr == "DA" ? string_parse(st, sz, 10, true) :
-    vr == "DT" ? string_parse(st, sz, 26, false) :
-    vr == "TM" ? string_parse(st, sz, 16, false) :
-    read!(st, Array{UInt8}(undef, sz))
-
-    if isodd(sz) && sz != 0xffffffff
-        skip(st, 1)
-    end
-
-    # For convenience, get rid of array if it is just acting as a container
-    # Exception is "SQ", where array is part of structure
-    if length(data) == 1 && vr != "SQ"
-        data = data[1]
-        if length(data) == 1
-            data = data[1]
-        end
-    end
-
-    # Return vr by default
-    return(gelt, data, vr)
-end
-
-# todo: support maxlen
-string_write(vals::Array{SubString{String}}, maxlen) = string_write(convert(Array{String}, vals), maxlen)
-string_write(vals::SubString{String}, maxlen) = string_write(convert(String, vals), maxlen)
-string_write(vals::Tuple{String, String}, maxlen) = string_write(collect(vals), maxlen)
-string_write(vals::Char, maxlen) = string_write(string(vals), maxlen)
-string_write(vals::String, maxlen) = string_write([vals], maxlen)
-string_write(vals::Array{String,1}, maxlen) = join(vals, '\\')
-
-element_write(st::IO, evr::Bool, gelt::Tuple{UInt16,UInt16}, data::Any) = element_write(st,evr,gelt,data,lookup_vr(gelt))
-function element_write(st::IO, evr::Bool, gelt::Tuple{UInt16,UInt16}, data::Any, vr::String)
-    if vr === emptyVR
-        # Element tags ending in 0x0000 are not included in dcm_dicm.jl, their vr is UL
-        if gelt[2] == 0x0000
-            vr = "UL"
-        elseif isodd(gelt[1]) && gelt[1] > 0x0008 && 0x0010 <= gelt[2] <+ 0x00FF
-                # Private creator
-                vr = "LO"
-        elseif isodd(gelt[1]) && gelt[1] > 0x0008
-                # Assume private
-                vr = "UN"
-        else
-            error("dicom: unknown tag ", gelt)
-        end
-    end
-    if gelt == (0x7FE0, 0x0010)
-        return pixeldata_write(st, evr, data)
-    end
-
-    if vr == "SQ"
-        vr = evr ? vr : emptyVR
-        return dcm_store(st, gelt,
-                         s->sequence_write(s, evr, data), vr)
-    end
-
-    # Pack data into array container. This is to undo "data = data[1]" from element().
-    if !isa(data,Array) && vr in ("FL","FD","SL","SS","UL","US")
-        data = [data]
-    end
-
-    data =
-    isempty(data) ? UInt8[] :
-    vr in ("OB","OF","OW","ST","LT","UT") ? data :
-    vr in ("AE", "CS", "SH", "LO", "UI", "PN", "DA", "DT", "TM") ?
-        string_write(data, 0) :
-    vr == "FL" ? convert(Array{Float32,1}, data) :
-    vr == "FD" ? convert(Array{Float64,1}, data) :
-    vr == "SL" ? convert(Array{Int32,1},   data) :
-    vr == "SS" ? convert(Array{Int16,1},   data) :
-    vr == "UL" ? convert(Array{UInt32,1},  data) :
-    vr == "US" ? convert(Array{UInt16,1},  data) :
-    vr == "AT" ? [data...] :
-    vr in ("DS","IS") ? string_write(map(string,data), 0) :
-    data
-
-    if evr === false && gelt[1]>0x0002
-        vr = emptyVR
-    end
-
-    dcm_store(st, gelt, s->write(s, data), vr)
-end
-
-"""
-    dcm_parse(fn::AbstractString)
-
-Reads file fn and returns a Dict
-"""
-function dcm_parse(fn::AbstractString, giveVR=false; header=true, maxGrp=0xffff, dVR=Dict{Tuple{UInt16,UInt16},String}())
-    st = open(fn)
-    dcm = dcm_parse(st, giveVR; header=header, maxGrp=maxGrp, dVR=dVR)
-    close(st)
-    dcm
-end
-
-"""
-    dcm_parse(st::IO)
-
-Reads IO st and returns a Dict
-"""
-function dcm_parse(st::IO, giveVR=false; header=true, maxGrp=0xffff, dVR=Dict{Tuple{UInt16,UInt16},String}())
-    if header
-        # First 128 bytes are preamble - should be skipped
-        skip(st, 128)
-        # "DICM" identifier must be after preamble
-        sig = String(read!(st,Array{UInt8}(undef, 4)))
-        if sig != "DICM"
-            error("dicom: invalid file header")
-            # seek(st, 0)
-        end
-    end
-    # a bit of a hack to detect explicit VR. seek past the first tag,
-    # and check to see if a valid VR name is there
-    skip(st, 4)
-    sig = String(read!(st,Array{UInt8}(undef, 2)))
-    evr = sig in VR_names
-    skip(st, -6)
-    dcm = Dict{Tuple{UInt16,UInt16},Any}()
-    if giveVR
-        dcmVR = Dict{Tuple{UInt16,UInt16},String}()
-    end
-    endian = :little
-    while true
-        (gelt, data, vr) = element(st, evr, endian, dcm, dVR) # element(st, evr, dcm, dVR)
-        if gelt === emptyTag || gelt[1] > maxGrp
-            break
-        else
-            dcm[gelt] = data
-            if giveVR
-                dcmVR[gelt] = vr
-            end
-        end
-        # look for transfer syntax UID
-        if gelt == (0x0002,0x0010)
-            # Default is endian=little, explicitVR=true
-            metaInfo = get(meta_uids, data, (false, true))
-            evr = metaInfo[2]
-            if metaInfo[1]
-                endian = :big
-            else
-                endian = :little
-            end
-        end
-    end
-    if giveVR
-        return(dcm,dcmVR)
-    else
-        return(dcm)
-    end
-end
-
-dcm_write(fn::String, d::Dict{Tuple{UInt16,UInt16},Any}, dVR=Dict{Tuple{UInt16,UInt16},String}()) = dcm_write(open(fn,"w+"),d,dVR)
-function dcm_write(st::IO, d::Dict{Tuple{UInt16,UInt16},Any}, dVR=Dict{Tuple{UInt16,UInt16},String}())
-    write(st, zeros(UInt8, 128))
-    write(st, "DICM")
-    # If no dictionary containing VRs is provided, then assume implicit VR - at first
-    evr = !isempty(dVR)
-    if !haskey(d,(0x0002,0x0010))
-        # Insert UID for our transfer syntax, if it doesn't exist
-        if evr
-            element_write(st, evr, (0x0002,0x0010), "1.2.840.10008.1.2.1", "UI")
-        else
-            element_write(st, evr, (0x0002,0x0010), "1.2.840.10008.1.2", "UI")
-        end
-    else
-        # Otherwise, use existing transfer UID, and overwrite evr accordingly
-        metaInfo = get(meta_uids, d[(0x0002,0x0010)], (false, true))
-        evr = metaInfo[2]
-    end
-    # dVR is only used if it isn't empty and evr=true
-    if evr && !isempty(dVR)
-        for gelt in sort(collect(keys(d)))
-            # dVR only needs to contain keys for cases where lookup_vr() fails
-            haskey(dVR, gelt) ? element_write(st, evr, gelt, d[gelt], dVR[gelt]) :
-                element_write(st, evr, gelt, d[gelt])
-        end
-    else
-        for gelt in sort(collect(keys(d)))
-            element_write(st, evr, gelt, d[gelt])
-        end
-    end
-    close(st)
 end
 
 end

--- a/test/DICOM_test.jl
+++ b/test/DICOM_test.jl
@@ -1,3 +1,0 @@
-using DICOM
-
-# todo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ const dicom_samples = Dict(
     "MR_Explicit_Little_MultiFrame.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/MR_Explicit_Little_MultiFrame.dcm",
     "MR_Implicit_Little.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/MR_Implicit_Little.dcm",
     "MR_UnspecifiedLength.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/MR_UnspecifiedLength.dcm",
-    "OT_Implicit_Little_Headless.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/OT_Implicit_Little_Headless.dcm"
+    "OT_Implicit_Little_Headless.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/OT_Implicit_Little_Headless.dcm",
+    "US_Explicit_Big_RGB.dcm" => "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/US_Explicit_Big_RGB.dcm"
 )
 
 function download_dicom(filename; folder = data_folder)
@@ -144,6 +145,13 @@ end
     fileMR_UnspecifiedLength = download_dicom("MR_UnspecifiedLength.dcm")
     dcmMR_UnspecifiedLength = dcm_parse(fileMR_UnspecifiedLength)
     @test size(dcmMR_UnspecifiedLength[tag"Pixel Data"]) === (256, 256, 27)
+end
+
+@testset "Test big endian" begin
+    fileUS = download_dicom("US_Explicit_Big_RGB.dcm")
+    dcmUS = dcm_parse(fileUS)
+    @test Int(dcmUS[(0x7fe0, 0x0000)]) == 921612
+    @test size(dcmUS[(0x7fe0, 0x0010)]) == (640, 480, 3)
 end
 
 @testset "Test tag macro" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using DICOM
 
-const data_folder = joinpath(@__DIR__,"testdata")
+const data_folder = joinpath(@__DIR__, "testdata")
 if !isdir(data_folder)
     mkdir(data_folder)
 end
@@ -32,25 +32,25 @@ end
     fileCT = download_dicom("CT_Explicit_Little.dcm")
     fileMG = download_dicom("MG_Explicit_Little.dcm")
 
-    dcmMR_partial = dcm_parse(fileMR, max_group=0x0008)
+    dcmMR_partial = dcm_parse(fileMR, max_group = 0x0008)
     dcmMR = dcm_parse(fileMR)
     dcmCT = dcm_parse(fileCT)
     (dcmMG, vrMG) = dcm_parse(fileMG, return_vr = true)
 
-    @test dcmMR_partial[(0x0008,0x0060)] == "MR"
-    @test haskey(dcmMR_partial, (0x7FE0,0x0010)) == false
+    @test dcmMR_partial[(0x0008, 0x0060)] == "MR"
+    @test haskey(dcmMR_partial, (0x7FE0, 0x0010)) == false
 
-    @test dcmMR[(0x0008,0x0060)] == "MR"
-    @test dcmCT[(0x0008,0x0060)] == "CT"
-    @test dcmMG[(0x0008,0x0060)] == "MG"
+    @test dcmMR[(0x0008, 0x0060)] == "MR"
+    @test dcmCT[(0x0008, 0x0060)] == "CT"
+    @test dcmMG[(0x0008, 0x0060)] == "MG"
 
-    @test length(dcmMR[(0x7FE0,0x0010)]) == 65536
-    @test length(dcmCT[(0x7FE0,0x0010)]) == 262144
-    @test length(dcmMG[(0x7FE0,0x0010)]) == 262144
+    @test length(dcmMR[(0x7FE0, 0x0010)]) == 65536
+    @test length(dcmCT[(0x7FE0, 0x0010)]) == 262144
+    @test length(dcmMG[(0x7FE0, 0x0010)]) == 262144
 
     # Test lookup-by-fieldname
-    @test dcmMR[(0x0008,0x0060)] == lookup(dcmMR, "Modality")
-    @test dcmMR[(0x7FE0,0x0010)] == lookup(dcmMR, "Pixel Data")
+    @test dcmMR[(0x0008, 0x0060)] == lookup(dcmMR, "Modality")
+    @test dcmMR[(0x7FE0, 0x0010)] == lookup(dcmMR, "Pixel Data")
 end
 
 @testset "Writing DICOM" begin
@@ -60,86 +60,86 @@ end
 
     dcmMR = dcm_parse(fileMR)
     dcmCT = dcm_parse(fileCT)
-    (dcmMG, vrMG) = dcm_parse(fileMG, return_vr=true)
+    (dcmMG, vrMG) = dcm_parse(fileMG, return_vr = true)
 
     # Define two output files for each dcm - data will be saved, reloaded, then saved again
-    outMR1 = joinpath(data_folder,"outMR1.dcm")
-    outMR2 = joinpath(data_folder,"outMR2.dcm")
-    outCT1 = joinpath(data_folder,"outCT1.dcm")
-    outCT2 = joinpath(data_folder,"outCT2.dcm")
-    outMG1 = joinpath(data_folder,"outMG1.dcm")
-    outMG1b = joinpath(data_folder,"outMG1b.dcm")
-    outMG2 = joinpath(data_folder,"outMG2.dcm")
+    outMR1 = joinpath(data_folder, "outMR1.dcm")
+    outMR2 = joinpath(data_folder, "outMR2.dcm")
+    outCT1 = joinpath(data_folder, "outCT1.dcm")
+    outCT2 = joinpath(data_folder, "outCT2.dcm")
+    outMG1 = joinpath(data_folder, "outMG1.dcm")
+    outMG1b = joinpath(data_folder, "outMG1b.dcm")
+    outMG2 = joinpath(data_folder, "outMG2.dcm")
 
     # Write DICOM files
-    outIO = open(outMR1, "w+"); dcm_write(outIO,dcmMR); close(outIO)
-    outIO = open(outCT1, "w+"); dcm_write(outIO,dcmCT); close(outIO)
-    outIO = open(outMG1, "w+"); dcm_write(outIO,dcmMG,aux_vr=vrMG); close(outIO)
-    dcm_write(outMG1b,dcmMG,aux_vr=vrMG)
+    outIO = open(outMR1, "w+"); dcm_write(outIO, dcmMR); close(outIO)
+    outIO = open(outCT1, "w+"); dcm_write(outIO, dcmCT); close(outIO)
+    outIO = open(outMG1, "w+"); dcm_write(outIO, dcmMG, aux_vr = vrMG); close(outIO)
+    dcm_write(outMG1b, dcmMG, aux_vr = vrMG)
     # Reading DICOM files which were written from previous step
     dcmMR1 = dcm_parse(outMR1)
     dcmCT1 = dcm_parse(outCT1)
-    (dcmMG1, vrMG1) = dcm_parse(outMG1, return_vr=true)
+    (dcmMG1, vrMG1) = dcm_parse(outMG1, return_vr = true)
     # Write DICOM files which were re-read from previous step
-    outIO = open(outMR2, "w+"); dcm_write(outIO,dcmMR1); close(outIO)
-    outIO = open(outCT2, "w+"); dcm_write(outIO,dcmCT1); close(outIO)
-    outIO = open(outMG2, "w+"); dcm_write(outIO,dcmMG1, aux_vr=vrMG1); close(outIO)
+    outIO = open(outMR2, "w+"); dcm_write(outIO, dcmMR1); close(outIO)
+    outIO = open(outCT2, "w+"); dcm_write(outIO, dcmCT1); close(outIO)
+    outIO = open(outMG2, "w+"); dcm_write(outIO, dcmMG1, aux_vr = vrMG1); close(outIO)
 
     # Test consistency of written files after the write-read-write cycle
-    @test read(outMR1)==read(outMR2)
-    @test read(outCT1)==read(outCT2)
-    @test read(outMG1)==read(outMG2)
+    @test read(outMR1) == read(outMR2)
+    @test read(outCT1) == read(outCT2)
+    @test read(outMG1) == read(outMG2)
 
     # Repeat first testset on written data
-    @test dcmMR1[(0x0008,0x0060)] == "MR"
-    @test dcmCT1[(0x0008,0x0060)] == "CT"
-    @test dcmMG1[(0x0008,0x0060)] == "MG"
+    @test dcmMR1[(0x0008, 0x0060)] == "MR"
+    @test dcmCT1[(0x0008, 0x0060)] == "CT"
+    @test dcmMG1[(0x0008, 0x0060)] == "MG"
 
-    @test length(dcmMR1[(0x7FE0,0x0010)]) == 65536
-    @test length(dcmCT1[(0x7FE0,0x0010)]) == 262144
-    @test length(dcmMG1[(0x7FE0,0x0010)]) == 262144
+    @test length(dcmMR1[(0x7FE0, 0x0010)]) == 65536
+    @test length(dcmCT1[(0x7FE0, 0x0010)]) == 262144
+    @test length(dcmMG1[(0x7FE0, 0x0010)]) == 262144
 
     # Test lookup-by-fieldname; cross-compare dcmMR with dcmMR1
-    @test dcmMR1[(0x0008,0x0060)] == lookup(dcmMR, "Modality")
-    @test dcmMR1[(0x7FE0,0x0010)] == lookup(dcmMR, "Pixel Data")
+    @test dcmMR1[(0x0008, 0x0060)] == lookup(dcmMR, "Modality")
+    @test dcmMR1[(0x7FE0, 0x0010)] == lookup(dcmMR, "Pixel Data")
 end
 
 @testset "Uncommon DICOM" begin
     # 1. DICOM file with missing preamble
     fileOT = download_dicom("OT_Implicit_Little_Headless.dcm")
-    dcmOT = dcm_parse(fileOT, preamble=false)
-    @test dcmOT[(0x0008,0x0060)] == "OT"
+    dcmOT = dcm_parse(fileOT, preamble = false)
+    @test dcmOT[(0x0008, 0x0060)] == "OT"
 
     # 2. DICOM file with missing preamble and retired DICOM elements
     fileCT = download_dicom("CT_Implicit_Little_Headless_Retired.dcm")
     # 2a. Read with user-supplied VRs
     dVR_CTa = Dict(
-        (0x0008,0x0010) => "SH",
-        (0x0008,0x0040) => "US",
-        (0x0008,0x0041) => "LO",
-        (0x0018,0x1170) => "DS",
-        (0x0020,0x0030) => "DS",
-        (0x0020,0x0035) => "DS",
-        (0x0020,0x0050) => "DS",
-        (0x0020,0x0070) => "LO",
-        (0x0028,0x0005) => "US",
-        (0x0028,0x0040) => "CS",
-        (0x0028,0x0200) => "US")
-    dcmCTa = dcm_parse(fileCT, preamble=false, aux_vr=dVR_CTa);
+        (0x0008, 0x0010) => "SH",
+        (0x0008, 0x0040) => "US",
+        (0x0008, 0x0041) => "LO",
+        (0x0018, 0x1170) => "DS",
+        (0x0020, 0x0030) => "DS",
+        (0x0020, 0x0035) => "DS",
+        (0x0020, 0x0050) => "DS",
+        (0x0020, 0x0070) => "LO",
+        (0x0028, 0x0005) => "US",
+        (0x0028, 0x0040) => "CS",
+        (0x0028, 0x0200) => "US")
+    dcmCTa = dcm_parse(fileCT, preamble = false, aux_vr = dVR_CTa);
     # 2b. Read with a master VR which skips elements
     # Here we skip any element where lookup_vr() fails
     # And we also force (0x0018,0x1170) to be read as float instead of integer
-    dVR_CTb = Dict( (0x0000,0x0000) => "",  (0x0018,0x1170) => "DS")
-    dcmCTb = dcm_parse(fileCT, preamble=false, aux_vr=dVR_CTb);
-    @test dcmCTa[(0x0008,0x0060)] == "CT"
-    @test dcmCTb[(0x0008,0x0060)] == "CT"
-    @test haskey(dcmCTa, (0x0028,0x0040)) # dcmCTa should contain retired element
-    @test !haskey(dcmCTb, (0x0028,0x0040)) # dcmCTb skips retired elements
+    dVR_CTb = Dict( (0x0000, 0x0000) => "",  (0x0018, 0x1170) => "DS")
+    dcmCTb = dcm_parse(fileCT, preamble = false, aux_vr = dVR_CTb);
+    @test dcmCTa[(0x0008, 0x0060)] == "CT"
+    @test dcmCTb[(0x0008, 0x0060)] == "CT"
+    @test haskey(dcmCTa, (0x0028, 0x0040)) # dcmCTa should contain retired element
+    @test !haskey(dcmCTb, (0x0028, 0x0040)) # dcmCTb skips retired elements
 
     # 3. DICOM file containing multiple frames
     fileMR_multiframe = download_dicom("MR_Explicit_Little_MultiFrame.dcm")
     dcmMR_multiframe = dcm_parse(fileMR_multiframe)
-    @test dcmMR_multiframe[(0x0008,0x0060)] == "MR"
+    @test dcmMR_multiframe[(0x0008, 0x0060)] == "MR"
 
     # 4. DICOM with unspecified_length()
     fileMR_UnspecifiedLength = download_dicom("MR_UnspecifiedLength.dcm")


### PR DESCRIPTION
This PR started as an attempt to incorporate the additions from PR #18 but then it got out of hand. 
Sorry about that.

With the PR, the package is now able to read big-endian data. 
However, it still can not correctly write big-endian files. 
A workaround is to change the transfer-syntax by
```
dcm_data[(0x0002, 0x0010)] = "1.2.840.10008.1.2.1"
```
and then `dcm_write` will save the data as little-endian.

This PR also changes the optional arguments to `dcm_parse` and `dcm_write`, so it can break older code. 
The optional arguments are now keywords (described in the summary below). 
Any suggestions to the keywords are welcome.

I want to manually test the PR on different machines before merging it and this will probably take me a week.
If there are no objections until then, then I will go ahead and merge.

---
Summary of changes:

- Support parsing big-endian data (from #18)
- Refactor `dcm_parse()` into smaller functions
    + In particular: the [meta info](http://dicom.nema.org/dicom/2013/output/chtml/part10/chapter_7.html) (which is always explicit VR and little endian) is parsed in a separate function while the body (which can be implicit VR or big endian) is parsed by a separate function
        + The explicitness/endianness is determined after reading the meta info. I think this makes the logic clearer than the previous version
- Shuffled the functions around in `DICOM.jl`
    + I prefer the main function to appear first, followed by the smaller/supporting functions. The old version had the smaller functions first, while the two main functions (`dcm_parse` and `dcm_write`) were at the end
- Fix some of my poor choices back in PR #22
    + Changed the variable names from camelCase to snake_case since that's the more julian style
    + Changed the optional arguments to `dcm_parse`. They are now all keywords and are as follows:
        + `return_vr::Bool` controls whether to return the VRs with the parsed data. Default: `false`
        + `preamble::Bool` controls whether the 128-bytes + "DICM" preamble is present. This was previously `header`. Default: `true`
        + `aux_vr` is a user-supplied dictionary which can supplement/override the dictionary in `src/dcm_dict.jl`. This was previously named `dVR`.
    + Changed the optional argument to `dcm_write`. It used to not be a keyword, but now it has the keyword `aux_vr`.
- Update readme so that it uses the newer/above syntax
- Fix a bug with parsing pixeldata
    + Previously, the pixel data had dimensions of `xr=rows`, `yr=columns`, where `rows` and `columns` are values from the dicom header. The updated version has the order swapped, i.e. `xr=columns`, `yr=rows`.
    + This was not caught in any of the previous tests because they all had the same number of rows and columns. However, on non-square images, the old version produces artifacts.
- Support RGB pixeldata
    + It currently assumes that the channels are seperated (i.e. `Planar configuration = 1`). If the channels are interlaced then the user will have to de-interlace them.
- Added a new test which is big-endian & RGB
- Added windows to the travis tests & replaced the code-coverage script with a simpler/default version